### PR TITLE
Add option to write sidecar file with additional metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unlike Gloria the flat-coated retriever mix, `mets-retriever` is all about fetch
 After installing with pip (see below), use the `retrieve-mets` command.
 
 `retrieve-mets` has two subcommands, `fetch-all` and `fetch-one`. Both
-subcommands have common arguments:
+subcommands have some common arguments:
 
 * METS files are fetched to a directory specified with the `--output-dir`
 argument. If one is not provided, a `mets_files` directory will be created
@@ -60,14 +60,16 @@ Usage: retrieve-mets fetch-all [OPTIONS]
   Fetch all METS files not already retrieved.
 
 Options:
-  --ss-url TEXT      Storage Service host URL  [default:
-                     http://127.0.0.1:62081; required]
-  --ss-api-key TEXT  Storage Service API key  [default: test; required]
-  --output-dir TEXT  Path to output directory  [default: mets_files; required]
-  --sidecar          Write sidecar file for each METS with Storage Location
-                     and AIP replica UUIDs
-
-  --help             Show this message and exit.
+  --ss-url TEXT         Storage Service host URL  [default:
+                        http://127.0.0.1:62081; required]
+  --ss-api-key TEXT     Storage Service API key  [default: test; required]
+  --output-dir TEXT     Path to output directory  [default: mets_files;
+                        required]
+  --sidecar             Write sidecar file for each METS with Storage Location
+                        and AIP replica UUIDs
+  --with-replicas-only  Only retrieve METS for an AIP if a replica has also
+                        been stored
+  --help                Show this message and exit.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ in the current directory and METS files will be written there.
 * Storage Service credentials must be included using the `--ss-url` and
 `--ss-api-key` arguments for both commands. By default these default to values
 from the Archivematica Docker development environment.
+* If the `--sidecar` flag is passed, a sidecar txt file will be written
+alongside each METS file in the output directory with additional metadata about
+the AIP not found in the METS file, namely, the storage location UUID and the
+UUIDs of any AIP replicas.
 
 ```
 Usage: retrieve-mets [OPTIONS] COMMAND [ARGS]...
@@ -60,6 +64,9 @@ Options:
                      http://127.0.0.1:62081; required]
   --ss-api-key TEXT  Storage Service API key  [default: test; required]
   --output-dir TEXT  Path to output directory  [default: mets_files; required]
+  --sidecar          Write sidecar file for each METS with Storage Location
+                     and AIP replica UUIDs
+
   --help             Show this message and exit.
 
 ```
@@ -85,6 +92,8 @@ Options:
                      http://127.0.0.1:62081; required]
   --ss-api-key TEXT  Storage Service API key  [default: test; required]
   --output-dir TEXT  Path to output directory  [default: mets_files; required]
+  --sidecar          Write sidecar file for each METS with Storage Location
+                     and AIP replica UUIDs
   --help             Show this message and exit.
 
 ```

--- a/mets_retriever/cli.py
+++ b/mets_retriever/cli.py
@@ -31,12 +31,18 @@ def retriever():
     default="mets_files",
     show_default=True,
 )
-def get_mets_files(ss_url, ss_api_key, output_dir):
+@click.option(
+    "--sidecar",
+    is_flag=True,
+    help="Write sidecar file for each METS with Storage Location and AIP replica UUIDs",
+)
+def get_mets_files(ss_url, ss_api_key, output_dir, sidecar):
     """Fetch all METS files not already retrieved."""
     retriever = METSRetriever(
         storage_service_url=ss_url,
         storage_service_api_key=ss_api_key,
         output_directory=output_dir,
+        add_sidecar=sidecar,
     )
     retriever.download_all_mets_files()
 
@@ -63,13 +69,19 @@ def get_mets_files(ss_url, ss_api_key, output_dir):
     default="mets_files",
     show_default=True,
 )
+@click.option(
+    "--sidecar",
+    is_flag=True,
+    help="Write sidecar file for each METS with Storage Location and AIP replica UUIDs",
+)
 @click.argument("aip-uuid")
-def get_mets_file(ss_url, ss_api_key, output_dir, aip_uuid):
+def get_mets_file(ss_url, ss_api_key, output_dir, sidecar, aip_uuid):
     """Fetch single METS file, even if it's already been retrieved."""
     retriever = METSRetriever(
         storage_service_url=ss_url,
         storage_service_api_key=ss_api_key,
         output_directory=output_dir,
+        add_sidecar=sidecar,
     )
     retriever.download_mets_file(aip_uuid)
 

--- a/mets_retriever/cli.py
+++ b/mets_retriever/cli.py
@@ -36,7 +36,12 @@ def retriever():
     is_flag=True,
     help="Write sidecar file for each METS with Storage Location and AIP replica UUIDs",
 )
-def get_mets_files(ss_url, ss_api_key, output_dir, sidecar):
+@click.option(
+    "--with-replicas-only",
+    is_flag=True,
+    help="Only retrieve METS for an AIP if a replica has also been stored",
+)
+def get_mets_files(ss_url, ss_api_key, output_dir, sidecar, with_replicas_only):
     """Fetch all METS files not already retrieved."""
     retriever = METSRetriever(
         storage_service_url=ss_url,
@@ -44,7 +49,7 @@ def get_mets_files(ss_url, ss_api_key, output_dir, sidecar):
         output_directory=output_dir,
         add_sidecar=sidecar,
     )
-    retriever.download_all_mets_files()
+    retriever.download_all_mets_files(with_replicas_only=with_replicas_only)
 
 
 @retriever.command("fetch-one")

--- a/mets_retriever/mets_retriever.py
+++ b/mets_retriever/mets_retriever.py
@@ -128,7 +128,7 @@ class METSRetriever:
             if aip["status"] == "UPLOADED" and aip["replicated_package"] is None
         ]
 
-    def download_all_mets_files(self):
+    def download_all_mets_files(self, with_replicas_only=False):
         am = AMClient(
             ss_url=self.storage_service_url,
             ss_user_name=self.storage_service_username,
@@ -136,6 +136,10 @@ class METSRetriever:
         )
         aips = self._filter_aips(am.aips())
         for aip in aips:
+            if with_replicas_only:
+                if not aip.get("replicas"):
+                    continue
+
             aip_uuid = aip["uuid"]
             if not self.check_if_aip_in_database(aip_uuid):
                 try:

--- a/mets_retriever/mets_retriever.py
+++ b/mets_retriever/mets_retriever.py
@@ -136,9 +136,8 @@ class METSRetriever:
         )
         aips = self._filter_aips(am.aips())
         for aip in aips:
-            if with_replicas_only:
-                if not aip.get("replicas"):
-                    continue
+            if with_replicas_only and not aip.get("replicas"):
+                continue
 
             aip_uuid = aip["uuid"]
             if not self.check_if_aip_in_database(aip_uuid):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mets-retriever
-version = 0.1.0
+version = 0.2.0
 author = Artefactual Systems, Inc.
 author_email = info@artefactual.com
 description = Python library and CLI tool to download Archivematica METS files

--- a/tests/test_mets_retriever.py
+++ b/tests/test_mets_retriever.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 import pytest
 
@@ -17,6 +18,51 @@ def test_database_helpers(retriever):
     assert retriever.check_if_aip_in_database(AIP_UUID) is False
     retriever.add_aip_to_database(AIP_UUID)
     assert retriever.check_if_aip_in_database(AIP_UUID) is True
+
+
+@pytest.mark.parametrize(
+    "package_details, expected_output",
+    [
+        # Test with multiple AIP replicas.
+        (
+            {
+                "current_location": "/api/v2/location/0c2be2cf-02b8-48ab-b264-75aef504289e/",
+                "replicas": [
+                    "/api/v2/file/2674e2c5-95a4-4058-b453-66983e47144d/",
+                    "/api/v2/file/75426ade-38df-4736-a457-b219e5cadb3b/",
+                ],
+            },
+            "Storage location: /api/v2/location/0c2be2cf-02b8-48ab-b264-75aef504289e/\nAIP replicas: /api/v2/file/2674e2c5-95a4-4058-b453-66983e47144d/, /api/v2/file/75426ade-38df-4736-a457-b219e5cadb3b/\n",
+        ),
+        # Test with one AIP replica.
+        (
+            {
+                "current_location": "/api/v2/location/0c2be2cf-02b8-48ab-b264-75aef504289e/",
+                "replicas": ["/api/v2/file/2674e2c5-95a4-4058-b453-66983e47144d/"],
+            },
+            "Storage location: /api/v2/location/0c2be2cf-02b8-48ab-b264-75aef504289e/\nAIP replicas: /api/v2/file/2674e2c5-95a4-4058-b453-66983e47144d/\n",
+        ),
+        # Test with no replicas.
+        (
+            {
+                "current_location": "/api/v2/location/0c2be2cf-02b8-48ab-b264-75aef504289e/",
+                "replicas": [],
+            },
+            "Storage location: /api/v2/location/0c2be2cf-02b8-48ab-b264-75aef504289e/\nAIP replicas: \n",
+        ),
+    ],
+)
+def test_write_sidecar_file(mocker, package_details, expected_output):
+    get_package_details = mocker.patch("amclient.AMClient.get_package_details")
+    get_package_details.return_value = package_details
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        retriever = mets_retriever.METSRetriever(output_directory=output_dir)
+        retriever.write_sidecar_file("test-uuid")
+
+        sidecar_filepath = os.path.join(output_dir, "METS.test-uuid.txt")
+        with open(sidecar_filepath, "r") as sidecar_file:
+            assert sidecar_file.read() == expected_output
 
 
 def test_download_mets_file(retriever, mocker):


### PR DESCRIPTION
This PR adds an option to `mets-retriever` to download a sidecar .txt file for each METS file containing the UUIDs of the AIP's storage location and AIP replicas. This information is not available in the METS file but is needed by the client sponsoring this work, so we decided on a sidecar file as the solution.

Additionally a `--with-replicas-only` flag has been added to the `fetch-all` command. When this flag is used, `mets-retriever` will only fetch a METS and/or sidecar file for AIPs that have replicas already stored. This is added to ensure the METS file and sidecar files aren't fetched for the client in the time between a large AIP being stored and its replicas being stored, which would otherwise leave the potential for the sidecar file's metadata to be incomplete.