### PR TITLE
Add replica location info to sidecar

### DIFF
--- a/mets_retriever/mets_retriever.py
+++ b/mets_retriever/mets_retriever.py
@@ -17,6 +17,8 @@ logger.addHandler(handler)
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 DATABASE_FILE = os.path.join(THIS_DIR, "mets.db")
 
+API_FILE_PREFIX = "/api/v2/file/"
+
 Base = declarative_base()
 
 
@@ -78,7 +80,7 @@ class METSRetriever:
         """Return list of AIP replica locations."""
         replica_locations = []
         for replica in replicas:
-            uuid = replica.replace("/api/v2/file/", "").rstrip("/")
+            uuid = replica.replace(API_FILE_PREFIX, "").rstrip("/")
             am = AMClient(
                 ss_url=self.storage_service_url,
                 ss_user_name=self.storage_service_username,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mets-retriever
-version = 0.2.0
+version = 0.2.1
 author = Artefactual Systems, Inc.
 author_email = info@artefactual.com
 description = Python library and CLI tool to download Archivematica METS files


### PR DESCRIPTION
This commit adds a new field to the sidecar file for AIP replica storage locations, per client request. The replicas and their storage locations will be comma-separated lists matched by index