### PR TITLE
Add Storage Service username CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ subcommands have some common arguments:
 * METS files are fetched to a directory specified with the `--output-dir`
 argument. If one is not provided, a `mets_files` directory will be created
 in the current directory and METS files will be written there.
-* Storage Service credentials must be included using the `--ss-url` and
-`--ss-api-key` arguments for both commands. By default these default to values
-from the Archivematica Docker development environment.
+* Storage Service credentials must be included using the `--ss-url`,
+`--ss-user-name`, and `--ss-api-key` arguments for both commands. By default
+these default to values from the Archivematica Docker development environment.
 * If the `--sidecar` flag is passed, a sidecar txt file will be written
 alongside each METS file in the output directory with additional metadata about
 the AIP not found in the METS file, namely, the storage location UUID and the
@@ -62,13 +62,15 @@ Usage: retrieve-mets fetch-all [OPTIONS]
 Options:
   --ss-url TEXT         Storage Service host URL  [default:
                         http://127.0.0.1:62081; required]
+  --ss-user-name TEXT   Storage Service username  [default: test;
+                        required]
   --ss-api-key TEXT     Storage Service API key  [default: test; required]
   --output-dir TEXT     Path to output directory  [default: mets_files;
                         required]
-  --sidecar             Write sidecar file for each METS with Storage Location
-                        and AIP replica UUIDs
-  --with-replicas-only  Only retrieve METS for an AIP if a replica has also
-                        been stored
+  --sidecar             Write sidecar file for each METS with Storage
+                        Location and AIP replica UUIDs
+  --with-replicas-only  Only retrieve METS for an AIP if a replica has 
+                        also been stored
   --help                Show this message and exit.
 
 ```
@@ -90,13 +92,15 @@ Usage: retrieve-mets fetch-one [OPTIONS] AIP_UUID
   Fetch single METS file, even if it's already been retrieved.
 
 Options:
-  --ss-url TEXT      Storage Service host URL  [default:
-                     http://127.0.0.1:62081; required]
-  --ss-api-key TEXT  Storage Service API key  [default: test; required]
-  --output-dir TEXT  Path to output directory  [default: mets_files; required]
-  --sidecar          Write sidecar file for each METS with Storage Location
-                     and AIP replica UUIDs
-  --help             Show this message and exit.
+  --ss-url TEXT       Storage Service host URL  [default:
+                      http://127.0.0.1:62081; required]
+  --ss-user-name TEXT Storage Service username  [default: test; required]
+  --ss-api-key TEXT   Storage Service API key  [default: test; required]
+  --output-dir TEXT   Path to output directory  [default: mets_files;
+                      required]
+  --sidecar           Write sidecar file for each METS with Storage 
+                      Location and AIP replica UUIDs
+  --help              Show this message and exit.
 
 ```
 

--- a/mets_retriever/cli.py
+++ b/mets_retriever/cli.py
@@ -18,6 +18,13 @@ def retriever():
     show_default=True,
 )
 @click.option(
+    "--ss-user-name",
+    required=True,
+    help="Storage Service username",
+    default="test",
+    show_default=True,
+)
+@click.option(
     "--ss-api-key",
     required=True,
     help="Storage Service API key",
@@ -41,11 +48,14 @@ def retriever():
     is_flag=True,
     help="Only retrieve METS for an AIP if a replica has also been stored",
 )
-def get_mets_files(ss_url, ss_api_key, output_dir, sidecar, with_replicas_only):
+def get_mets_files(
+    ss_url, ss_user_name, ss_api_key, output_dir, sidecar, with_replicas_only
+):
     """Fetch all METS files not already retrieved."""
     retriever = METSRetriever(
         storage_service_url=ss_url,
         storage_service_api_key=ss_api_key,
+        storage_service_username=ss_user_name,
         output_directory=output_dir,
         add_sidecar=sidecar,
     )
@@ -58,6 +68,13 @@ def get_mets_files(ss_url, ss_api_key, output_dir, sidecar, with_replicas_only):
     required=True,
     help="Storage Service host URL",
     default="http://127.0.0.1:62081",
+    show_default=True,
+)
+@click.option(
+    "--ss-user-name",
+    required=True,
+    help="Storage Service username",
+    default="test",
     show_default=True,
 )
 @click.option(
@@ -80,11 +97,12 @@ def get_mets_files(ss_url, ss_api_key, output_dir, sidecar, with_replicas_only):
     help="Write sidecar file for each METS with Storage Location and AIP replica UUIDs",
 )
 @click.argument("aip-uuid")
-def get_mets_file(ss_url, ss_api_key, output_dir, sidecar, aip_uuid):
+def get_mets_file(ss_url, ss_user_name, ss_api_key, output_dir, sidecar, aip_uuid):
     """Fetch single METS file, even if it's already been retrieved."""
     retriever = METSRetriever(
         storage_service_url=ss_url,
         storage_service_api_key=ss_api_key,
+        storage_service_username=ss_user_name,
         output_directory=output_dir,
         add_sidecar=sidecar,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mets-retriever
-version = 0.2.1
+version = 0.2.2
 author = Artefactual Systems, Inc.
 author_email = info@artefactual.com
 description = Python library and CLI tool to download Archivematica METS files


### PR DESCRIPTION
This PR fixes a defect where the Storage Service username is hardcoded to "test" when using the CLI, which prevents proper authentication.